### PR TITLE
Adding more currencies

### DIFF
--- a/ethtools.js
+++ b/ethtools.js
@@ -46,7 +46,9 @@ Check for supported currencies
 var supportedCurrencies = function(unit){
     return (unit === 'usd' ||
            unit === 'eur' ||
-           unit === 'btc');
+           unit === 'btc' ||
+           unit === 'gbp' ||
+           unit === 'brl');
 };
 
 /**
@@ -62,7 +64,7 @@ var getUnit = function(unit){
 
         if(!unit) {
             unit = 'ether';
-            LocalStore.set('dapp_etherUnit', unit);        
+            LocalStore.set('dapp_etherUnit', unit);
         }
     }
 
@@ -196,11 +198,11 @@ EthTools.formatNumber = function(number, format){
         var afterDecimal = number.replace(beforeDecimal, '').substr(0, length);
         var afterDecimalOptional = number.replace(beforeDecimal, '').substr(length, optionalLength).replace(/0*$/,'');
         beforeDecimal = beforeDecimal.replace(options.decimalSeparator, '');
-        
+
         return (!afterDecimal && !afterDecimalOptional)
             ? beforeDecimal
             : beforeDecimal + options.decimalSeparator + afterDecimal + afterDecimalOptional;
-    
+
     // otherwise simply return the formated number
     } else {
         return number;
@@ -227,7 +229,7 @@ EthTools.formatBalance = function(number, format, unit){
         format = null;
 
     format = format || '0,0.[00000000]';
-    
+
     unit = getUnit(unit);
 
     if(typeof EthTools.ticker !== 'undefined' && supportedCurrencies(unit)) {

--- a/ticker.js
+++ b/ticker.js
@@ -4,12 +4,14 @@ if(Meteor.isClient)
     new PersistentMinimongo(EthTools.ticker);
 
 EthTools.ticker.start = function(options){
-    var url = 'https://min-api.cryptocompare.com/data/price?fsym=ETH&tsyms=BTC,USD,EUR';
-
     options = options || {};
-
-    if(options.extraParams)
+    if (!options.currencies){
+        options.currencies = ['BTC', 'USD', 'EUR'];
+    }
+    var url = 'https://min-api.cryptocompare.com/data/price?fsym=ETH&tsyms=' + options.currencies.join(',');
+    if (options.extraParams) {
         url += '&extraParams='+ options.extraParams;
+    }
 
     var updatePrice = function(e, res){
 
@@ -37,10 +39,9 @@ EthTools.ticker.start = function(options){
 
     // update right away
     HTTP.get(url, updatePrice);
-        
+
     // update prices
     Meteor.setInterval(function(){
-        HTTP.get(url, updatePrice);    
+        HTTP.get(url, updatePrice);
     }, 1000 * 30);
 }
-


### PR DESCRIPTION
- Keeps default currencies as BTC, EUR, USD.
- Adds GBP and BRL as "supported currencies".
- Allows cryptocomare API to be called with any combination of supported currencies.