### PR TITLE
add all other currencies supported by cryptocompare.com.

### DIFF
--- a/ethtools-tests.js
+++ b/ethtools-tests.js
@@ -150,6 +150,22 @@ Tinytest.add("EthTools.formatBalance", function(test) {
     "1.0000000000000000000"
   );
 
+  // check all other currencies
+  var currencies = ['jpy', 'aud', 'cad', 'chf', 'cny', 'sek', 'nzd', 'mxn', 'sgd', 'nok',
+                    'krw', 'try', 'rub', 'inr', 'brl', 'zar'];
+  currencies.forEach(function (cur) {
+    // set price
+    EthTools.ticker.upsert(cur, {$set: { price: '1.00000', timestamp: null }});
+    test.equal(
+      EthTools.formatBalance(
+        "1000000000000000000",
+        "0,0.0000000000000000000",
+        cur
+      ),
+      "1.0000000000000000000"
+    );
+  });
+
   // reset
   if (Meteor.isClient) EthTools.setUnit("ether");
 });

--- a/ethtools.js
+++ b/ethtools.js
@@ -43,13 +43,10 @@ Check for supported currencies
 @return {String}
 */
 var supportedCurrencies = function(unit) {
-  return (
-    unit === "usd" ||
-    unit === "eur" ||
-    unit === "btc" ||
-    unit === "gbp" ||
-    unit === "brl"
-  );
+  // https://en.wikipedia.org/wiki/Currency
+  var currencies = ['btc', 'usd', 'eur', 'jpy', 'gbp', 'aud', 'cad', 'chf', 'cny', 'sek',
+                    'nzd', 'mxn', 'sgd', 'nok', 'krw', 'try', 'rub', 'inr', 'brl', 'zar'];
+  return (currencies.indexOf(unit) > -1);
 };
 
 /**


### PR DESCRIPTION
See also #3 and
https://min-api.cryptocompare.com/data/price?fsym=ETH&tsyms=BTC,USD,EUR,BRL,GBP,JPY,AUD,CAD,CHF,CNY,SEK,NZD,MXN,SQD,NOK,KRW,TRY,RUB,INR,ZAR

and snippet.
~~~.js
var currencies = ['BTC', 'USD', 'EUR', 'BRL', 'GBP', 'JPY', 'AUD', 'CAD', 'CHF',
                  'CNY', 'SEK', 'NZD', 'MXN', 'SQD', 'NOK', 'KRW', 'TRY', 'RUB',
                  'INR', 'ZAR'];
var options = { currencies: currencies };
EthTools.ticker.start(options);
~~~